### PR TITLE
twicks and typos

### DIFF
--- a/4-Reranking_Week2.ipynb
+++ b/4-Reranking_Week2.ipynb
@@ -73,7 +73,7 @@
     "from torch.nn import Sigmoid\n",
     "\n",
     "# external libraries\n",
-    "from sentence_transformers import CrossEncoder\n",
+    "from sentence_transformers import CrossEncoder, SentenceTransformer\n",
     "from tqdm.notebook import tqdm\n",
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -161,7 +161,7 @@
    "outputs": [],
    "source": [
     "#set class name to run queries on\n",
-    "class_name = 'Fine_tuned_on_300'"
+    "class_name = None"
    ]
   },
   {
@@ -376,7 +376,7 @@
    "id": "2c977e88-b580-4fb8-b499-6a97c2f934b8",
    "metadata": {},
    "source": [
-    "### Multiple by weighted alpha value\n",
+    "### Multiply by weighted alpha value\n",
     "\n",
     "Weight the values by multiplying by the `alpha` parameter. `alpha` is an indication of how strong we want to weight the scores toward vector search.  Setting `alpha` to 0 results in a pure keyword search (vector scores will be multiplied by 0, meaning they won't be considered as part of the search results) and setting `alpha` to 1 results in a pure vector-based search. For this example we'll set `alpha` to `0.45` meaning we'll multiply the vector scores by `0.45` (thus diminishing their importance to the returned results) and multiply the keyword scores by `0.55` (boosting their importance to the returned results).  "
    ]
@@ -655,12 +655,12 @@
     "\n",
     "response = (client.query\n",
     "            \n",
-    "    .get(clas_name=None, properties=display_properties)  #reminder that the properties param here refers to the \"display_properties\"\n",
+    "    .get(class_name=None, properties=display_properties)  #reminder that the properties param here refers to the \"display_properties\"\n",
     "    \n",
     "    # use near_vector our search method, and only search over the \"content\" property\n",
     "    .with_hybrid( query=None,\n",
     "                  alpha=None,\n",
-    "                  vector: List[float]=None,  # to compare against the embeddings representing the \"content\" property\n",
+    "                  vector=None,  # to compare against the embeddings representing the \"content\" property\n",
     "                  properties=None,   # NOT the display_properties, these are the properties that will use BM25 for search\n",
     "                  fusion_type='relativeScoreFusion')\n",
     "    \n",
@@ -981,7 +981,7 @@
     "    end = time.perf_counter() - start\n",
     "    return round(end, 3)\n",
     "\n",
-    "limit_values = list(range(10, 500,10))\n",
+    "limit_values = list(range(10, 300, 10))\n",
     "\n",
     "unranked_times = []\n",
     "for n in tqdm(limit_values, 'Search: No Reranker'):\n",


### PR DESCRIPTION
Fixed some typos.

Moved the latency to 300 because 500 was taking way to long (maybe i'll encourage to make it even smaller because of how long it takes in codespaces).

import SentenceTransformer to implement the hybrid search assignment