### PR TITLE
small fixes notebook 4

### DIFF
--- a/notebooks/4-Reranking_Week2.ipynb
+++ b/notebooks/4-Reranking_Week2.ipynb
@@ -421,7 +421,6 @@
    "outputs": [],
    "source": [
     "#scores and ranking are slightly off due to the way that keyword results are processed\n",
-    "#take a look at one of the 'explainScore' keys for one of the resuls in the hyb_response i.e. hyb_response[0]['explainScore']\n",
     "\n",
     "hyb_response = client.hybrid_search(query, collection_name, alpha=alpha, limit=5)\n",
     "get_scores_ids(hyb_response), ranked_results"
@@ -792,7 +791,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from evaluation.retrieval_evaluation import execute_evaluation\n",
+    "from src.evaluation.retrieval_evaluation import execute_evaluation\n",
     "from src.preprocessor.preprocessing import FileIO\n",
     "\n",
     "#################\n",


### PR DESCRIPTION
Small fixes in notebook 4:
- Remove reference to explainScore
- Fix reference to retrieval_evaluation: src.evaluation.retrieval_evaluation